### PR TITLE
Img uploads

### DIFF
--- a/web/ctf_gameserver/web/registration/fields.py
+++ b/web/ctf_gameserver/web/registration/fields.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from urllib.parse import urljoin
 from io import BytesIO
 
@@ -8,6 +9,10 @@ from django.conf import settings
 from django.utils.encoding import filepath_to_uri
 from django.utils.html import conditional_escape, format_html
 from PIL import Image
+
+# force an error when image decompression takes too much memory
+Image.MAX_IMAGE_PIXELS = 1000*1000
+warnings.simplefilter('error', Image.DecompressionBombWarning)
 
 
 class ThumbnailImageFieldFile(ImageFieldFile):

--- a/web/ctf_gameserver/web/registration/fields.py
+++ b/web/ctf_gameserver/web/registration/fields.py
@@ -17,18 +17,27 @@ warnings.simplefilter('error', Image.DecompressionBombWarning)
 
 class ThumbnailImageFieldFile(ImageFieldFile):
     """
-    Custom variant of ImageFieldFile which automatically generates a thumbnail when saving an image.
+    Custom variant of ImageFieldFile which automatically generates a thumbnail when saving an image and
+    stores the serialized PIL image instead of the raw input data to disk.
     """
 
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
+    def save(self, name, content, *args, **kwargs):
+        image = content.image
+
+        # We store a newly serialized version of the image, to (hopefully) prevent attacks where users
+        # upload a valid image file that might also be interpreted as HTML/JS due to content sniffing.
+        # If we didn't convert everything to PNG, we'd also have to take care to only allow file
+        # extensions for which the web server sends a image/* mime type.
+        data = BytesIO()
+        image.save(data, 'PNG')
+        data.seek(0)
+        super().save(name, data, *args, **kwargs)
 
         thumbnail_data = BytesIO()
-
-        image = Image.open(self.storage.open(self.name))
-        image.thumbnail(settings.THUMBNAIL_SIZE)
-        image.save(thumbnail_data, 'PNG')
-
+        thumbnail = image.copy()
+        thumbnail.thumbnail(settings.THUMBNAIL_SIZE)
+        thumbnail.save(thumbnail_data, 'PNG')
+        thumbnail_data.seek(0)
         self.storage.save(self.get_thumbnail_path(), thumbnail_data)
 
     # Keep property of the parent method
@@ -46,17 +55,11 @@ class ThumbnailImageFieldFile(ImageFieldFile):
         """
         Returns the path of the image's thumbnail version relative to the storage root (i.e. its "name" in
         storage system terms).
-        Thumbnails have the same base name as their original images with a '.png' extension and are stored in
-        a 'thumbnails' directory alongside the original images.
+        Thumbnails have the same name as their original images stored in a 'thumbnails' directory alongside
+        the original images.
         """
         path, filename = os.path.split(self.name)
-
-        path = os.path.join(path, 'thumbnails')
-        filename_parts = os.path.splitext(filename)
-        # Include the original extension to keep the relationship between image and thumbnail unique
-        filename = '{}-{}.png'.format(filename_parts[0], filename_parts[1][1:])
-
-        return os.path.join(path, filename)
+        return os.path.join(path, 'thumbnails', filename)
 
     def get_thumbnail_url(self):
         """
@@ -67,7 +70,7 @@ class ThumbnailImageFieldFile(ImageFieldFile):
 
 class ThumbnailImageField(ImageField):
     """
-    Custom variant of ImageField which uses ThumbnailImageFieldFile for its instances.
+    Custom variant of ImageField which automatically resizes and re-serializes an uploaded image.
     """
 
     attr_class = ThumbnailImageFieldFile

--- a/web/ctf_gameserver/web/registration/forms.py
+++ b/web/ctf_gameserver/web/registration/forms.py
@@ -11,7 +11,6 @@ from .fields import ClearableThumbnailImageInput
 from .util import email_token_generator, get_country_names
 
 FIVE_MB = 5 * 1024**2
-ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif']
 
 
 class UserForm(forms.ModelForm):
@@ -149,11 +148,8 @@ class TeamForm(forms.ModelForm):
         self.fields['country'].choices = [('', '----------')] + self.fields['country'].choices
 
     def clean_image(self):
-        if self.cleaned_data['image']:
-            if self.cleaned_data['image'].size > FIVE_MB:
-                raise forms.ValidationError(_('The file must not be larger than 5 MB!'))
-            if not any(self.cleaned_data['image'].path.endswith(ext) for ext in ALLOWED_EXTENSIONS):
-                raise forms.ValidationError(_('The image does not have a known file extension.'))
+        if self.cleaned_data['image'] and self.cleaned_data['image'].size > FIVE_MB:
+            raise forms.ValidationError(_('The file must not be larger than 5 MB!'))
 
         return self.cleaned_data['image']
 

--- a/web/ctf_gameserver/web/registration/models.py
+++ b/web/ctf_gameserver/web/registration/models.py
@@ -12,10 +12,8 @@ def _gen_image_name(instance, filename):
     Returns the upload path (relative to settings.MEDIA_ROOT) for the specified Team's image.
     """
 
-    extension = os.path.splitext(filename)[1]
-
     # Must "return a Unix-style path (with forward slashes)"
-    return 'team-images' + '/' + instance.user.username + extension
+    return 'team-images' + '/' + str(instance.user.id) + '.png'
 
 
 class Team(models.Model):

--- a/web/ctf_gameserver/web/static/style.css
+++ b/web/ctf_gameserver/web/static/style.css
@@ -46,6 +46,8 @@ th.border-right, td.border-right {
 
 .team-image {
     width: 50px;
+    max-height: 50px;
+    object-fit: contain;
 }
 
 #mail-teams-content {


### PR DESCRIPTION
I still need to test this, but it should fix #19.

> We should also catch PIL/Pillow exception at opening (it will throw OSError for non-imge files)

Django should already be doing that for us [1]. I've also changed the code to make use of the `Image` instance it provides us with (but I'll still need to test that this actually works, for now I've only read the Django code to figure out which object stores the image instance).

> How would you generate filenames? Adding a database field ...
AFAICT there's already a database field (the generated file name is only used if that name is available, otherwise a random file name is used instead [2]). Using the team id for the default file name still seems like a good idea though.

1: https://docs.djangoproject.com/en/2.0/ref/forms/fields/#django.forms.ImageField
2: https://github.com/django/django/blob/64b74804c537b12d4cca64f7cb529c0478b4c4d9/django/core/files/storage.py#L279