### PR TITLE
Uniq state per team for local runns

### DIFF
--- a/src/ctf_gameserver/checkerlib/lib.py
+++ b/src/ctf_gameserver/checkerlib/lib.py
@@ -18,7 +18,7 @@ from ctf_gameserver.lib.checkresult import CheckResult
 
 
 _TIMEOUT_SECONDS = 10.0    # Default timeout for socket operations
-_LOCAL_STATE_PATH = '_state.json'
+_LOCAL_STATE_PATH = '_{team:d}_state.json'
 
 _ctrl_in = None    # pylint: disable=invalid-name
 _ctrl_out = None    # pylint: disable=invalid-name
@@ -195,6 +195,9 @@ def run_check(checker_cls: Type[BaseChecker]) -> None:
     ip = sys.argv[1]
     team = int(sys.argv[2])
     tick = int(sys.argv[3])
+
+    global _LOCAL_STATE_PATH
+    _LOCAL_STATE_PATH  = _LOCAL_STATE_PATH.format(team=team)
 
     if _launched_without_runner():
         # Hack because get_flag() only needs to know the team when launched locally


### PR DESCRIPTION
Preserves the semantics of the "real" checker by making the checker
state per-team. This way it's easier to keep distinct team ids around
for development.