### PR TITLE
go-checkerlib: make LoadState() more usable

### DIFF
--- a/docs/checkers/go-library.md
+++ b/docs/checkers/go-library.md
@@ -36,7 +36,9 @@ care of calling your methods, merging the results and submitting them to the Che
 
 ### Persistent State
 * `StoreState(key string, data interface{})`: Store data persistently across runs (serialized as JSON).
-* `LoadState(key string) interface{}`: Retrieve data stored through `StoreState()`.
+  Data is stored per service and team with the given key as an additional identifier.
+* `LoadState(key string, data interface{}) bool`: Retrieve data stored through `StoreState()` (deserialized into
+  `data`). Returns `true` if any state was found.
 
 ### Helper functions
 * `Dial(network, address string) (net.Conn, error)`: Calls `net.DialTimeout()` with an appropriate timeout.

--- a/go/checkerlib/lib.go
+++ b/go/checkerlib/lib.go
@@ -190,22 +190,22 @@ func StoreState(key string, data interface{}) {
 	}
 }
 
-// LoadState allows to retrieve data stored through StoreState. If no data
-// exists for the given key (and the current service and team), nil is
-// returned.
-func LoadState(key string) interface{} {
-	var data string
+// LoadState allows to retrieve data stored through StoreState by unmarshalling it into data.
+// If no data exists for the given key (and the current service and team)
+// false is returned.
+func LoadState(key string, data interface{}) bool {
+	var dataJson string
 	if ipc.in != nil {
 		x := ipc.SendRecv("LOAD", key)
 		if x == nil {
-			return nil
+			return false
 		}
-		data = x.(string)
+		dataJson = x.(string)
 	} else {
 		x, err := ioutil.ReadFile(localStatePath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return nil
+				return false
 			}
 			panic(err)
 		}
@@ -217,23 +217,23 @@ func LoadState(key string) interface{} {
 		}
 
 		var ok bool
-		data, ok = state[key]
+		dataJson, ok = state[key]
 		if !ok {
-			return nil
+			return false
 		}
 	}
 
 	// Deserialize data
-	x, err := base64.StdEncoding.DecodeString(data)
+	x, err := base64.StdEncoding.DecodeString(dataJson)
 	if err != nil {
 		panic(err)
 	}
-	var res interface{}
-	err = json.Unmarshal(x, &res)
+
+	err = json.Unmarshal(x, data)
 	if err != nil {
 		panic(err)
 	}
-	return res
+	return true
 }
 
 // RunCheck launches the execution of the specified Checker implementation.


### PR DESCRIPTION
Add a ptr argument to LoadState() to make it easier to use. Now you can pass a pointer to the data structure you want and `json.Unmarshal` will honor the structure instead of returning something generic.
Without it even a `map[string]string` gets turned into a `map[string]interface{}` which is ugly to use.

Yes this is a breaking change, but I doubt many people currently use the go-checkerlib except me. And because of the `go.sum` file you should only get this update if you specifically request it.
