### PR TITLE
fix attack scoring

### DIFF
--- a/doc/controller/scoring.sql
+++ b/doc/controller/scoring.sql
@@ -64,7 +64,7 @@ WITH
   )
 SELECT team_id,
        service_id,
-       coalesce(attack, 0)::double precision as attack,
+       (coalesce(attack, 0)+coalesce(bonus, 0))::double precision as attack,
        coalesce(bonus, 0) as bonus,
        coalesce(defense, 0)::double precision as defense,
        coalesce(sla, 0) as sla,

--- a/src/ctf_gameserver/controller/database.py
+++ b/src/ctf_gameserver/controller/database.py
@@ -40,7 +40,7 @@ def update_scoring(db_conn):
 
     with transaction_cursor(db_conn) as cursor:
         cursor.execute('UPDATE scoring_flag as outerflag'
-                       '    SET bonus = 1 / ('
+                       '    SET bonus = 1.0 / ('
                        '        SELECT greatest(1, count(*))'
                        '        FROM scoring_flag'
                        '        LEFT OUTER JOIN scoring_capture ON scoring_capture.flag_id = scoring_flag.id'


### PR DESCRIPTION
Without this
- `bonus` always is an integer. Which we do not want. e.g two teams capturing a flag must be bonus 0.5.
- `bonus` column is completely hidden from scoreboard. Which makes scoring super intransparent for teams