### PR TITLE
eagerly update flag bonus and update scoreboard on game end

### DIFF
--- a/src/ctf_gameserver/controller/controller.py
+++ b/src/ctf_gameserver/controller/controller.py
@@ -181,6 +181,9 @@ def main_loop_step(db_conn, metrics, nonstop):
         return
 
     if (not nonstop) and (now >= control_info['end']):
+        # Update scoring for last tick of game
+        database.update_scoring(db_conn)
+
         # Do not stop the program because a daemon might get restarted if it exits
         # Prevent a busy loop in case we have not slept above as the hypothetic next tick would be overdue
         logging.info('Competition is already over')

--- a/src/ctf_gameserver/controller/database.py
+++ b/src/ctf_gameserver/controller/database.py
@@ -46,8 +46,9 @@ def update_scoring(db_conn):
                        '        LEFT OUTER JOIN scoring_capture ON scoring_capture.flag_id = scoring_flag.id'
                        '        WHERE scoring_capture.flag_id = outerflag.id)'
                        '    FROM scoring_gamecontrol'
-                       '    WHERE outerflag.tick + scoring_gamecontrol.valid_ticks < '
-                       '        scoring_gamecontrol.current_tick AND outerflag.bonus IS NULL')
+                       '    WHERE outerflag.tick >='
+                       '        scoring_gamecontrol.current_tick - scoring_gamecontrol.valid_ticks'
+                       '        OR outerflag.bonus IS NULL')
         cursor.execute('REFRESH MATERIALIZED VIEW "scoring_scoreboard"')
 
 


### PR DESCRIPTION
Fix #71

- Update the flag bonus not just when the flag has expired but as long as it is not expired (5 ticks). This way the bonus of a capture does not need 5 ticks to show up one the scoreboard. Note however that this way the bonus (and thus the attack points) might decrease when other teams capture the same flag in later ticks
- call `update_scoring` when game has ended to include last tick in scoreboard