### PR TITLE
Clarify that ticks start from zero in checkerlib documentation

### DIFF
--- a/docs/checkers/go-library.md
+++ b/docs/checkers/go-library.md
@@ -85,10 +85,10 @@ Gameserver repository](https://github.com/fausecteam/ctf-gameserver).
 Local Execution
 ---------------
 When running your Checker Script locally, just pass your service IP, the tick to check and a dummy team ID
-as command line arguments:
+as command line arguments (Tick starts from zero):
 
 ```sh
-go build && ./checkerscript ::1 10 1
+go build && ./checkerscript ::1 10 0
 ```
 
 The library will print messages to stderr and generate dummy flags when launched without a Checker Master.

--- a/docs/checkers/python-library.md
+++ b/docs/checkers/python-library.md
@@ -88,10 +88,10 @@ For a complete, but still simple, Checker Script see "examples/checker/example_c
 Local Execution
 ---------------
 When running your Checker Script locally, just pass your service IP, the tick to check and a dummy team ID
-as command line arguments:
+as command line arguments (Tick starts from zero):
 
 ```sh
-./checkerscript.py ::1 10 1
+./checkerscript.py ::1 10 0
 ```
 
 The library will print messages to stdout and generate dummy flags when launched without a Checker Master.


### PR DESCRIPTION
The example invocation given in the documentation has caused some confusion for new service authors.