### PR TITLE
Implement multiple flagstores per service

### DIFF
--- a/conf/controller/scoring.sql
+++ b/conf/controller/scoring.sql
@@ -28,22 +28,22 @@ WITH
     FROM flagdefense
     GROUP BY team_id, service_id
   ),
-  sla_ok AS (
-    SELECT count(*) as sla_ok,
-           team_id,
-           service_id
-    FROM scoring_statuscheck
-    WHERE status = 0
-    GROUP BY team_id, service_id
-  ),
-  sla_recover AS (
-    SELECT 0.5 * count(*) as sla_recover,
-           team_id,
-           service_id
-    FROM scoring_statuscheck
-    WHERE status = 4
-    GROUP BY team_id, service_id
-  ),
+--  sla_ok AS (
+--    SELECT count(*) as sla_ok,
+--           team_id,
+--           service_id
+--    FROM scoring_statuscheck
+--    WHERE status = 0
+--    GROUP BY team_id, service_id
+--  ),
+--  sla_recover AS (
+--    SELECT 0.5 * count(*) as sla_recover,
+--           team_id,
+--           service_id
+--    FROM scoring_statuscheck
+--    WHERE status = 4
+--    GROUP BY team_id, service_id
+--  ),
   teams as (
     SELECT user_id as team_id
     FROM registration_team
@@ -51,26 +51,98 @@ WITH
     WHERE is_active = true
 	  AND nop_team = false
   ),
-  sla AS (
+--  sla AS (
+--    SELECT (SELECT sqrt(count(*)) FROM teams) * (coalesce(sla_ok, 0) + coalesce(sla_recover, 0)) as sla,
+--           team_id,
+--           service_id
+--    FROM sla_ok
+--    NATURAL FULL OUTER JOIN sla_recover
+--  ),
+  fill AS (
+    SELECT team_id, scoring_servicegroup.id AS service_group_id
+    FROM teams, scoring_servicegroup
+  ),
+  servicegroup AS (
+    SELECT scoring_service.service_group_id AS service_group_id,
+           count(scoring_service.id) AS services_count
+    FROM scoring_service
+    GROUP BY scoring_service.service_group_id
+  ),
+  attack_by_servicegroup AS (
+    SELECT team_id,
+           scoring_service.service_group_id AS service_group_id,
+           sum(attack) AS attack,
+           sum(bonus) AS bonus
+    FROM attack
+    INNER JOIN scoring_service ON scoring_service.id = attack.service_id
+    GROUP BY team_id, scoring_service.service_group_id
+  ),
+  defense_by_servicegroup AS (
+    SELECT team_id,
+           scoring_service.service_group_id AS service_group_id,
+           sum(defense) AS defense
+    FROM defense
+    INNER JOIN scoring_service ON scoring_service.id = defense.service_id
+    GROUP BY team_id, scoring_service.service_group_id
+  ),
+  sla_ok_by_servicegroup_tick AS (
+    SELECT team_id,
+           scoring_service.service_group_id AS service_group_id,
+           0.5 * servicegroup.services_count * (COUNT(*) = servicegroup.services_count)::int AS sla_ok
+    FROM scoring_statuscheck
+    INNER JOIN scoring_service ON scoring_service.id = scoring_statuscheck.service_id
+    INNER JOIN servicegroup ON servicegroup.service_group_id = scoring_service.service_group_id
+    WHERE scoring_statuscheck.status = 0
+    GROUP BY team_id, scoring_service.service_group_id, servicegroup.services_count, scoring_statuscheck.tick
+  ),
+  sla_ok_by_servicegroup AS (
+    SELECT team_id,
+           service_group_id,
+           sum(sla_ok) AS sla_ok
+    FROM sla_ok_by_servicegroup_tick
+    GROUP BY team_id, service_group_id
+  ),
+  sla_recover_by_servicegroup_tick AS (
+    SELECT team_id,
+           scoring_service.service_group_id AS service_group_id,
+           0.5 * servicegroup.services_count * (COUNT(*) = servicegroup.services_count)::int AS sla_recover
+    FROM scoring_statuscheck
+    INNER JOIN scoring_service ON scoring_service.id = scoring_statuscheck.service_id
+    INNER JOIN servicegroup ON servicegroup.service_group_id = scoring_service.service_group_id
+    WHERE scoring_statuscheck.status = 4 OR scoring_statuscheck.status = 0
+    GROUP BY team_id, scoring_service.service_group_id, servicegroup.services_count, scoring_statuscheck.tick
+  ),
+  sla_recover_by_servicegroup AS (
+    SELECT team_id,
+           service_group_id,
+           sum(sla_recover) AS sla_recover
+    FROM sla_recover_by_servicegroup_tick
+    GROUP BY team_id, service_group_id
+  ),
+  sla_by_servicegroup AS (
     SELECT (SELECT sqrt(count(*)) FROM teams) * (coalesce(sla_ok, 0) + coalesce(sla_recover, 0)) as sla,
            team_id,
-           service_id
-    FROM sla_ok
-    NATURAL FULL OUTER JOIN sla_recover
-  ),
-  fill AS (
-    SELECT team_id, scoring_service.id AS service_id
-    FROM teams, scoring_service
+           service_group_id
+    FROM sla_ok_by_servicegroup
+    NATURAL FULL OUTER JOIN sla_recover_by_servicegroup
+--  ),
+--  sla_by_servicegroup AS ( -- alternative sla without interplay between servicegroups
+--    SELECT team_id,
+--           scoring_service.service_group_id AS service_group_id,
+--           sum(sla) AS sla
+--    FROM sla
+--    INNER JOIN scoring_service ON scoring_service.id = sla.service_id
+--    GROUP BY team_id, scoring_service.service_group_id
   )
 SELECT team_id,
-       service_id,
+       service_group_id,
        (coalesce(attack, 0)+coalesce(bonus, 0))::double precision as attack,
        coalesce(bonus, 0) as bonus,
        coalesce(defense, 0)::double precision as defense,
        coalesce(sla, 0) as sla,
        coalesce(attack, 0) + coalesce(defense, 0) + coalesce(bonus, 0) + coalesce(sla, 0) as total
-FROM attack
-NATURAL FULL OUTER JOIN defense
-NATURAL FULL OUTER JOIN sla
+FROM attack_by_servicegroup
+NATURAL FULL OUTER JOIN defense_by_servicegroup
+NATURAL FULL OUTER JOIN sla_by_servicegroup
 NATURAL INNER JOIN fill
-ORDER BY team_id, service_id;
+ORDER BY team_id, service_group_id;

--- a/examples/checker/example_checker.py
+++ b/examples/checker/example_checker.py
@@ -19,13 +19,13 @@ class ExampleChecker(checkerlib.BaseChecker):
             logging.info('Received response to SET command: %s', repr(resp))
         except UnicodeDecodeError:
             logging.warning('Received non-UTF-8 data: %s', repr(resp))
-            return checkerlib.CheckResult.FAULTY
+            return checkerlib.CheckResult.FAULTY, 'Received non-UTF-8 data'
         if resp != 'OK':
             logging.warning('Received wrong response to SET command')
-            return checkerlib.CheckResult.FAULTY
+            return checkerlib.CheckResult.FAULTY, 'Received wrong response to SET command'
 
         conn.close()
-        return checkerlib.CheckResult.OK
+        return checkerlib.CheckResult.OK, ''
 
     def check_service(self):
         conn = connect(self.ip)
@@ -37,10 +37,10 @@ class ExampleChecker(checkerlib.BaseChecker):
             logging.info('Received response to dummy command')
         except UnicodeDecodeError:
             logging.warning('Received non-UTF-8 data')
-            return checkerlib.CheckResult.FAULTY
+            return checkerlib.CheckResult.FAULTY, 'Received non-UTF-8 data'
 
         conn.close()
-        return checkerlib.CheckResult.OK
+        return checkerlib.CheckResult.OK, ''
 
     def check_flag(self, tick):
         flag = checkerlib.get_flag(tick)
@@ -54,13 +54,13 @@ class ExampleChecker(checkerlib.BaseChecker):
             logging.info('Received response to GET command: %s', repr(resp))
         except UnicodeDecodeError:
             logging.warning('Received non-UTF-8 data: %s', repr(resp))
-            return checkerlib.CheckResult.FAULTY
+            return checkerlib.CheckResult.FAULTY, 'Received non-UTF-8 data'
         if resp != flag:
             logging.warning('Received wrong response to GET command')
-            return checkerlib.CheckResult.FLAG_NOT_FOUND
+            return checkerlib.CheckResult.FLAG_NOT_FOUND, 'Received wrong response to GET command'
 
         conn.close()
-        return checkerlib.CheckResult.OK
+        return checkerlib.CheckResult.OK, ''
 
 
 def connect(ip):

--- a/src/ctf_gameserver/checker/supervisor.py
+++ b/src/ctf_gameserver/checker/supervisor.py
@@ -361,13 +361,12 @@ def handle_script_message(message, ctrlin_fd, runner_id, queue_to_master, pipe_f
 
     if action == ACTION_RESULT:
         try:
-            result = CheckResult(int(param))
-        except ValueError:
+            result = CheckResult(int(param['value']))
+            script_logger.info('[RUNNER] Checker Script result: %s, msg: %s', result.name, param['message'],
+                               extra={'result': result.value})
+        except ValueError | KeyError:
             # Ignore malformed message from the Checker Script, will be logged by the Master
             pass
-        else:
-            script_logger.info('[RUNNER] Checker Script result: %s', result.name,
-                               extra={'result': result.value})
 
     queue_to_master.put((runner_id, action, param))
     response = pipe_from_master.recv()

--- a/src/ctf_gameserver/checkerlib/__init__.py
+++ b/src/ctf_gameserver/checkerlib/__init__.py
@@ -1,1 +1,1 @@
-from .lib import BaseChecker, CheckResult, get_flag, set_flagid, load_state, run_check, store_state
+from .lib import BaseChecker, CheckResult, get_flag, set_flagid, get_flagid, load_state, run_check, store_state

--- a/src/ctf_gameserver/web/scoring/admin.py
+++ b/src/ctf_gameserver/web/scoring/admin.py
@@ -6,6 +6,12 @@ from ctf_gameserver.web.admin import admin_site
 from . import models, forms
 
 
+@admin.register(models.ServiceGroup, site=admin_site)
+class ServiceGroupAdmin(admin.ModelAdmin):
+
+    prepopulated_fields = {'slug': ('name',)}
+
+
 @admin.register(models.Service, site=admin_site)
 class ServiceAdmin(admin.ModelAdmin):
 
@@ -67,8 +73,8 @@ class CaptureAdmin(admin.ModelAdmin):
 @admin.register(models.StatusCheck, site=admin_site)
 class StatusCheckAdmin(admin.ModelAdmin):
 
-    list_display = ('id', 'service', 'team', 'tick', 'status')
-    list_filter = ('service', 'tick', 'status')
+    list_display = ('id', 'service', 'team', 'tick', 'status', 'message')
+    list_filter = ('service', 'tick', 'status', 'message')
     search_fields = ('service__name', 'team__user__username')
     ordering = ('tick', 'timestamp')
 

--- a/src/ctf_gameserver/web/scoring/calculations.py
+++ b/src/ctf_gameserver/web/scoring/calculations.py
@@ -6,6 +6,18 @@ from ctf_gameserver.web.registration.models import Team
 from . import models
 
 
+STATUS_PRIORITY = [
+    0,  # up
+    4,  # recovering
+    3,  # flag not found
+    2,  # faulty
+    1,  # down
+    -1, # not checked
+]
+
+STATUS_PRIORITY_DICT = {n:i for i,n in enumerate(STATUS_PRIORITY)}
+
+
 def scores(select_related_fields=None, only_fields=None):
     """
     Returns the scores as currently stored in the database as an OrderedDict in this format:
@@ -24,11 +36,11 @@ def scores(select_related_fields=None, only_fields=None):
 
     if select_related_fields is None:
         select_related_fields = []
-    select_related_fields = list(set(select_related_fields + ['service', 'team']))
+    select_related_fields = list(set(select_related_fields + ['service_group', 'team']))
     if only_fields is None:
         only_fields = []
     only_fields = list(set(only_fields +
-                           ['attack', 'defense', 'sla', 'total', 'service__id', 'team__user__id']))
+                           ['attack', 'defense', 'sla', 'total', 'service_group__id', 'team__user__id']))
 
     # No good way to invalidate the cache, so use a generic key with a short timeout
     cache_key = 'scores'
@@ -40,11 +52,11 @@ def scores(select_related_fields=None, only_fields=None):
     team_scores = defaultdict(lambda: {'offense': [{}, 0], 'defense': [{}, 0], 'sla': [{}, 0], 'total': 0})
 
     for score in models.ScoreBoard.objects.select_related(*select_related_fields).only(*only_fields).all():
-        team_scores[score.team]['offense'][0][score.service] = score.attack
+        team_scores[score.team]['offense'][0][score.service_group] = score.attack
         team_scores[score.team]['offense'][1] += score.attack
-        team_scores[score.team]['defense'][0][score.service] = score.defense
+        team_scores[score.team]['defense'][0][score.service_group] = score.defense
         team_scores[score.team]['defense'][1] += score.defense
-        team_scores[score.team]['sla'][0][score.service] = score.sla
+        team_scores[score.team]['sla'][0][score.service_group] = score.sla
         team_scores[score.team]['sla'][1] += score.sla
         team_scores[score.team]['total'] += score.total
 
@@ -88,13 +100,39 @@ def team_statuses(from_tick, to_tick, select_related_team_fields=None, only_team
     for team in team_qset.order_by('user__username').all():
         statuses[team] = defaultdict(lambda: {})
         teams[team.pk] = team
+        for tick in range(from_tick, to_tick+1):
+            statuses[team][tick] = defaultdict(lambda: {})
+
+    service_to_group = {}
+    services_by_group = {}
+
+    for service in models.Service.objects.all():
+        service_to_group[service.id] = service.service_group.id
+        if service.service_group.id in services_by_group:
+            services_by_group[service.service_group.id].append(service.id)
+        else:
+            services_by_group[service.service_group.id] = [service.id]
 
     status_checks = models.StatusCheck.objects.filter(tick__gte=from_tick, tick__lte=to_tick)
     for check in status_checks:
-        statuses[teams[check.team_id]][check.tick][check.service_id] = check.status
+        statuses[teams[check.team_id]][check.tick][service_to_group[check.service_id]][check.service_id] = (check.status, check.message)
+
+    for team in statuses.values():
+        for team_tick in team.values():
+             for group, services in services_by_group.items():
+                joint_status = 0
+                for service in services:
+                    if service not in team_tick[group]:
+                        team_tick[group][service] = (-1, '')
+                    status, _ = team_tick[group][service]
+                    if STATUS_PRIORITY_DICT[status] > STATUS_PRIORITY_DICT[joint_status]:
+                        joint_status = status
+                team_tick[group][-1] = joint_status
 
     # Convert defaultdicts to dicts because serialization in `cache.set()` can't handle them otherwise
     for key, val in statuses.items():
+        for key2, val2 in val.items():
+            statuses[key][key2] = dict(val2)
         statuses[key] = dict(val)
     cache.set(cache_key, statuses, 10)
 

--- a/src/ctf_gameserver/web/scoring/templates/scoreboard.html
+++ b/src/ctf_gameserver/web/scoring/templates/scoreboard.html
@@ -78,6 +78,12 @@
                     <span class="glyphicon glyphicon-dashboard"></span> <span class="sr-only">SLA</span>
                     <span><!-- SLA --></span> <br/>
 
+                    <span class="flagstore-group">
+                        <!-- <span class="glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="bottom" title="not checked"></span> -->
+                        <a tabindex="0" class="flagstore" role="button" data-toggle="popover" data-trigger="focus hover" data-placement="bottom"
+                              title="All flagstores" data-content="not checked"><span class="glyphicon glyphicon-question-sign text-muted">
+                            </span></a>
+                    </span>
                     <a href="{% url 'service_status' %}">
                     <!-- Status -->
                     <span class="text-muted">{% trans 'not checked' %}</span>

--- a/src/ctf_gameserver/web/static/scoreboard.js
+++ b/src/ctf_gameserver/web/static/scoreboard.js
@@ -44,16 +44,39 @@ function buildTable(data) {
             const service_node = service_template.cloneNode(true)
 
             const spans = service_node.querySelectorAll('span')
+            const as = service_node.querySelectorAll('a')
             spans[2].textContent = service['offense'].toFixed(2)
             spans[5].textContent = service['defense'].toFixed(2)
             spans[8].textContent = service['sla'].toFixed(2)
 
-            service_node.querySelector('a').href += `#team-${team.id}-row`
+            as[1].href += `#team-${team.id}-row`
 
             if (service['status'] !== '') {
+                console.log(service)
+                console.log(service['flagstores'])
+                // TODO move up
+                const flagstore_classes = new Map();
+                flagstore_classes.set(-1, 'glyphicon glyphicon-question-sign text-muted'); // NOT_CHECKED
+                flagstore_classes.set(0, 'glyphicon glyphicon-ok-sign text-success'); // OK
+                flagstore_classes.set(1, 'glyphicon glyphicon-minus-sign text-danger'); // DOWN
+                flagstore_classes.set(2, 'glyphicon glyphicon-exclamation-sign text-danger'); // FAULTY
+                flagstore_classes.set(3, 'glyphicon glyphicon-question-sign text-warning'); // FLAG_NOT_FOUND
+                flagstore_classes.set(4, 'glyphicon glyphicon-plus-sign text-info'); // RECOVERING
+
+                var flagstore_id = 1;
+                for (const flagstore of service['flagstores']) {
+                    const fs_box = as[0].cloneNode(true)
+                    fs_box.firstElementChild.setAttribute('class', flagstore_classes.get(flagstore[0]))
+                    fs_box.setAttribute('title', `Flagstore ${flagstore_id}`)
+                    fs_box.setAttribute('data-content', flagstore[1] === '' ? 'up' : flagstore[1])
+                    spans[9].appendChild(fs_box)
+                    flagstore_id++
+                }
+                spans[9].removeChild(as[0])
+
                 const statusClass = statusClasses[service['status']]
-                spans[9].setAttribute('class', `text-${statusClass}`)
-                spans[9].textContent = statusDescriptions[service['status']]
+                spans[11].setAttribute('class', `text-${statusClass}`)
+                spans[11].textContent = statusDescriptions[service['status']]
 
                 service_node.setAttribute('class', statusClass)
             }
@@ -74,4 +97,9 @@ function buildTable(data) {
         template.parentNode.appendChild(entry)
         entry.hidden = false
     }
+
+    setTimeout(function () {
+        //$('[data-toggle="tooltip"]').tooltip()
+        $('[data-toggle="popover"]').popover()
+    }, 1000)
 }

--- a/src/ctf_gameserver/web/static/style.css
+++ b/src/ctf_gameserver/web/static/style.css
@@ -76,6 +76,15 @@ img#load-spinner, button#refresh {
     display: block;
 }
 
+img#load-spinner {
+    width: 1.7em;
+}
+
+img#load-spinner,
+button#refresh {
+    margin-right: 20px;
+}
+
 #history-table td a:hover {
     text-decoration: none;
 }
@@ -83,4 +92,16 @@ img#load-spinner, button#refresh {
 #check-list {
     margin-top: 20px;
     padding-left: 20px;
+}
+
+.flagstore-group {
+    margin-left: -2px;
+}
+
+.flagstore {
+    margin: 2px;
+}
+
+.flagstore:hover {
+    text-decoration: none;
 }


### PR DESCRIPTION
This PR copies the flagstore implementation from ECSC 2022.

To support multiple flagstores, multiple checker scripts have to be provided by the service authors. Each flagstore is then registered as a seperate service. Additionally, service categories group the flagstores to provide the "real" services.

Tested locally and the python checkerlib is confirmed working. I have tested multiple flagstore result combinations and they all behave as expected (`OK+OK -> OK`, `OK+FAULTY -> FAULTY`, `OK+NOT CHECKED -> NOT CHECKED`, etc.)

I suspect that the go checkerlib will need refactoring, because each (python) checker function additionally returns a message that is shown on the scoreboard. However, the go checkerlib has not been adapted to support this. I don't know whether we want to keep that feature. Furthermore, I know next to nothing about go, therefore someone else would need to take a look at it if we decide to keep it.

Additionally, I'm not sure about the scoring formula. AFAIK, each service group gets SLA points equal to `COUNT(FLAGSTORE)` iff all of them are OK. This should be easy to adapt though, once we decide on what scoring formula to use.

There is still some commented out SQL, which should be removed before merging.

Resolves #77